### PR TITLE
fix: resolve TypeScript build error from SpeechRecognition variable shadowing

### DIFF
--- a/src/hooks/use-voice-recording.ts
+++ b/src/hooks/use-voice-recording.ts
@@ -32,10 +32,10 @@ export function useVoiceRecording(options: VoiceRecordingOptions = {}): VoiceRec
 
   // Check browser support
   useEffect(() => {
-    const SpeechRecognition = window.SpeechRecognition || (window as any).webkitSpeechRecognition
-    if (SpeechRecognition) {
+    const SpeechRecognitionAPI = window.SpeechRecognition || (window as any).webkitSpeechRecognition
+    if (SpeechRecognitionAPI) {
       setIsSupported(true)
-      recognitionRef.current = new SpeechRecognition()
+      recognitionRef.current = new SpeechRecognitionAPI()
     } else {
       setIsSupported(false)
       setError('Speech recognition is not supported in this browser')


### PR DESCRIPTION
## Summary

Fixed TypeScript compilation error that was causing Firebase deploy to fail at the build step.

## Changes
- Renamed local variable from `SpeechRecognition` to `SpeechRecognitionAPI` in `src/hooks/use-voice-recording.ts`
- This resolves the variable name shadowing issue with the global `SpeechRecognition` constructor type

Related to #5