### PR TITLE
fix: add missing outDir to tsconfig.node.json for composite build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-node/
 .env
 *.log
 .DS_Store

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -9,6 +9,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "composite": true,
+    "outDir": "./dist-node",
     "emitDeclarationOnly": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Fixes #7

The TypeScript composite project configuration in tsconfig.node.json was missing the outDir option, which caused `tsc -b` to fail when trying to emit declaration files.

## Changes
- Added `outDir: "./dist-node"` to tsconfig.node.json
- Updated .gitignore to exclude the generated files

This fixes the build step in the Firebase deploy workflow.