### PR TITLE
fix: remove unused sheets-db-client local dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",
-    "sheets-db-client": "file:../sheets-db-api/sdk",
     "tailwind-merge": "^2.6.0",
     "uuid": "^13.0.0",
     "vite-plugin-pwa": "^1.2.0"


### PR DESCRIPTION
Fixes #7

The build was failing because package.json contained a local file dependency that doesn't exist in CI:
```json
"sheets-db-client": "file:../sheets-db-api/sdk"
```

This dependency was planned but never implemented, and is not used anywhere in the codebase. Removing it allows npm install to succeed in the CI environment.