### PR TITLE
fix: remove eslint.config.js from tsconfig.node.json to fix build

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -19,5 +19,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts", "eslint.config.js"]
+  "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
Fixes #7

The TypeScript build was failing because tsconfig.node.json included eslint.config.js (a JavaScript file) while having emitDeclarationOnly and declaration options enabled. TypeScript cannot emit declaration files for JavaScript files, causing tsc -b to fail.

## Changes
- Removed `eslint.config.js` from the include array in tsconfig.node.json since it's a JavaScript file that doesn't need TypeScript type checking for the build process.