### PR TITLE
Enable Save button when note content is present

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@playwright/test": "^1.49.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^22.10.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/src/components/note-form.tsx
+++ b/src/components/note-form.tsx
@@ -48,7 +48,7 @@ export function NoteForm({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!title.trim()) return
+    if (!title.trim() && !content.trim()) return
 
     // Stop recording if active
     if (isListening) {
@@ -88,7 +88,6 @@ export function NoteForm({
         placeholder="Note title..."
         value={title}
         onChange={(e) => setTitle(e.target.value)}
-        required
       />
       <div className="relative">
         <textarea
@@ -122,7 +121,7 @@ export function NoteForm({
             Cancel
           </Button>
         )}
-        <Button type="submit" disabled={isSubmitting || !title.trim()}>
+        <Button type="submit" disabled={isSubmitting || (!title.trim() && !content.trim())}>
           {isSubmitting ? 'Saving...' : submitLabel}
         </Button>
       </div>

--- a/tests/unit/note-form.test.tsx
+++ b/tests/unit/note-form.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { NoteForm } from '@/components/note-form'
+
+describe('NoteForm', () => {
+  it('should disable Save button when both title and content are empty', () => {
+    const onSubmit = vi.fn()
+    render(<NoteForm onSubmit={onSubmit} />)
+
+    const saveButton = screen.getByRole('button', { name: /save/i })
+    expect(saveButton).toBeDisabled()
+  })
+
+  it('should enable Save button when title has content', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    render(<NoteForm onSubmit={onSubmit} />)
+
+    const titleInput = screen.getByPlaceholderText('Note title...')
+    await user.type(titleInput, 'My Note')
+
+    const saveButton = screen.getByRole('button', { name: /save/i })
+    expect(saveButton).toBeEnabled()
+  })
+
+  it('should enable Save button when content has text', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    render(<NoteForm onSubmit={onSubmit} />)
+
+    const contentTextarea = screen.getByPlaceholderText('Write your note...')
+    await user.type(contentTextarea, 'Note content here')
+
+    const saveButton = screen.getByRole('button', { name: /save/i })
+    expect(saveButton).toBeEnabled()
+  })
+
+  it('should disable Save button when only whitespace is entered in title', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    render(<NoteForm onSubmit={onSubmit} />)
+
+    const titleInput = screen.getByPlaceholderText('Note title...')
+    await user.type(titleInput, '   ')
+
+    const saveButton = screen.getByRole('button', { name: /save/i })
+    expect(saveButton).toBeDisabled()
+  })
+
+  it('should disable Save button when only whitespace is entered in content', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    render(<NoteForm onSubmit={onSubmit} />)
+
+    const contentTextarea = screen.getByPlaceholderText('Write your note...')
+    await user.type(contentTextarea, '   ')
+
+    const saveButton = screen.getByRole('button', { name: /save/i })
+    expect(saveButton).toBeDisabled()
+  })
+
+  it('should enable Save button when both title and content have text', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    render(<NoteForm onSubmit={onSubmit} />)
+
+    const titleInput = screen.getByPlaceholderText('Note title...')
+    const contentTextarea = screen.getByPlaceholderText('Write your note...')
+
+    await user.type(titleInput, 'My Title')
+    await user.type(contentTextarea, 'My Content')
+
+    const saveButton = screen.getByRole('button', { name: /save/i })
+    expect(saveButton).toBeEnabled()
+  })
+
+  it('should call onSubmit when form is submitted with title only', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(<NoteForm onSubmit={onSubmit} />)
+
+    const titleInput = screen.getByPlaceholderText('Note title...')
+    await user.type(titleInput, 'My Title')
+
+    const saveButton = screen.getByRole('button', { name: /save/i })
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        title: 'My Title',
+        content: '',
+        tags: '',
+      })
+    })
+  })
+
+  it('should call onSubmit when form is submitted with content only', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn().mockResolvedValue(undefined)
+    render(<NoteForm onSubmit={onSubmit} />)
+
+    const contentTextarea = screen.getByPlaceholderText('Write your note...')
+    await user.type(contentTextarea, 'Just content')
+
+    const saveButton = screen.getByRole('button', { name: /save/i })
+    await user.click(saveButton)
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({
+        title: '',
+        content: 'Just content',
+        tags: '',
+      })
+    })
+  })
+
+  it('should show custom submit label', () => {
+    const onSubmit = vi.fn()
+    render(<NoteForm onSubmit={onSubmit} submitLabel="Update" />)
+
+    const updateButton = screen.getByRole('button', { name: /update/i })
+    expect(updateButton).toBeInTheDocument()
+  })
+
+  it('should populate form with initial values', () => {
+    const onSubmit = vi.fn()
+    const initialValues = {
+      title: 'Existing Title',
+      content: 'Existing Content',
+      tags: ['tag1', 'tag2'],
+    }
+    render(<NoteForm onSubmit={onSubmit} initialValues={initialValues} />)
+
+    const titleInput = screen.getByPlaceholderText('Note title...') as HTMLInputElement
+    const contentTextarea = screen.getByPlaceholderText('Write your note...') as HTMLTextAreaElement
+
+    expect(titleInput.value).toBe('Existing Title')
+    expect(contentTextarea.value).toBe('Existing Content')
+
+    const saveButton = screen.getByRole('button', { name: /save/i })
+    expect(saveButton).toBeEnabled()
+  })
+})


### PR DESCRIPTION
Fixes #16

### Changes

- Updated Save button disabled state to check for content OR title
- Button now enables when either field has non-whitespace text
- Removed required attribute from title field (auto-generation handles empty titles)
- Updated form validation to allow submission with content-only notes
- Added comprehensive test suite for Save button state logic

### Testing

New test file: `tests/unit/note-form.test.tsx` with 10 test cases covering:
- Empty form state
- Title-only input
- Content-only input
- Whitespace handling
- Form submission behavior
- Initial values

Generated with [Claude Code](https://claude.ai/code)