### PR TITLE
fix(markdown): render single newlines as <br> in view mode

### DIFF
--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -43,9 +43,11 @@ renderer.link = ({ href, text }) => {
   return `<a href="${escapeHtml(safeHref)}" target="_blank" rel="noopener noreferrer" class="text-[var(--accent-cyan)] hover:text-[var(--accent-purple)] underline underline-offset-2 transition-colors">${text}</a>`
 }
 
-// Override paragraph to add proper spacing
-renderer.paragraph = ({ text }) => {
-  return `<p class="mb-3">${text}</p>`
+// Override paragraph to add proper spacing.
+// Must use renderer.parser.parseInline(tokens) — not `text` — so that inline tokens
+// (including <br> from breaks:true) are rendered rather than passed through as raw text.
+renderer.paragraph = ({ tokens }) => {
+  return `<p class="mb-3">${renderer.parser.parseInline(tokens)}</p>`
 }
 
 // Override headings for styling
@@ -82,8 +84,19 @@ renderer.list = ({ items, ordered, start }) => {
 
 marked.setOptions({
   renderer,
-  breaks: true, // Convert \n to <br>
-  gfm: false, // Disable GFM to prevent auto-linking URLs (we handle that with regex)
+  breaks: true,
+  gfm: true, // Required for `breaks` to convert \n to <br>; URL auto-linking suppressed below
+})
+
+// Suppress GFM's URL auto-linker — our regex pass in renderMarkdown() handles linkification.
+// Returning undefined (not false) makes the wrapped tokenizer skip this token type entirely;
+// false would fall through to the original GFM tokenizer.
+marked.use({
+  tokenizer: {
+    url() {
+      return undefined
+    },
+  },
 })
 
 function escapeHtml(text: string): string {

--- a/tests/unit/markdown.test.tsx
+++ b/tests/unit/markdown.test.tsx
@@ -2,6 +2,33 @@ import { describe, it, expect } from 'vitest'
 import { render } from '@testing-library/react'
 import { renderMarkdown } from '@/lib/markdown'
 
+describe('renderMarkdown - single-newline soft breaks', () => {
+  it('renders single newlines as <br>', () => {
+    const { container } = render(<>{renderMarkdown('line one\nline two\nline three')}</>)
+    const brs = container.querySelectorAll('br')
+    expect(brs.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders double newlines as separate paragraphs', () => {
+    const { container } = render(<>{renderMarkdown('para one\n\npara two')}</>)
+    const paragraphs = container.querySelectorAll('p')
+    expect(paragraphs).toHaveLength(2)
+  })
+
+  it('linkifies plain URLs exactly once (no double-linking from GFM + regex)', () => {
+    const { container } = render(<>{renderMarkdown('Visit https://example.com today')}</>)
+    const links = container.querySelectorAll('a')
+    expect(links).toHaveLength(1)
+    expect(links[0]).toHaveAttribute('href', 'https://example.com')
+  })
+
+  it('rejects javascript: URLs in markdown links', () => {
+    const { container } = render(<>{renderMarkdown('[click](javascript:alert(1))')}</>)
+    const links = container.querySelectorAll('a')
+    expect(links).toHaveLength(0)
+  })
+})
+
 describe('renderMarkdown - nested list rendering', () => {
   it('renders depth-1 nesting: parent with indented children', () => {
     const md = '- parent\n  - child A\n  - child B'


### PR DESCRIPTION
## What

- Fixes #50 — single `\n` line breaks in note content were silently dropped in view mode
- Root cause was two-layered: (1) `gfm: false` disabled `breaks: true` per marked v17 docs, and (2) `renderer.paragraph` used the raw `text` field instead of `renderer.parser.parseInline(tokens)`, bypassing all inline token rendering including `<br>`
- Suppresses GFM URL auto-linking via a tokenizer override so the existing regex linkifier remains the sole linkification path (no double-linking regression)

## How

- `src/lib/markdown.tsx`: enable `gfm: true`, fix `renderer.paragraph` to call `parseInline(tokens)`, add URL tokenizer suppression
- `tests/unit/markdown.test.tsx`: new `describe` block covering single-newline `<br>`, double-newline paragraph break, URL single-linking, and `javascript:` URL rejection

## Test plan

- [x] `vitest run tests/unit/markdown.test.tsx` — 14/14 pass (4 new tests green)
- [x] `vitest run` — 148/148 pass, no regressions
- [ ] Manual smoke: edit note with `line one\nline two\nline three`, save, verify 3 lines visible in card and modal

## Docs shipped

No user-facing docs changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Luke, 2026-05-24
